### PR TITLE
Specify full golang toolchain version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fydrah/loginapp
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/cenkalti/backoff v2.2.1+incompatible


### PR DESCRIPTION
This is the correct way to specify the version as of 1.21

See https://go.dev/doc/toolchain#version